### PR TITLE
Rename the package `util` to `kotres`

### DIFF
--- a/src/jp/co/qoncept/kotres/Operators.kt
+++ b/src/jp/co/qoncept/kotres/Operators.kt
@@ -1,4 +1,4 @@
-package jp.co.qoncept.util
+package jp.co.qoncept.kotres
 
 infix fun <T, R, E: Exception> ((T) -> R).mp(result: Result<T, E>): Result<R, E> {
     return result.map(this)

--- a/src/jp/co/qoncept/kotres/Result.kt
+++ b/src/jp/co/qoncept/kotres/Result.kt
@@ -1,4 +1,4 @@
-package jp.co.qoncept.util
+package jp.co.qoncept.kotres
 
 sealed class Result<out T, out E: Exception> {
     abstract val value: T?

--- a/test/jp/co/qoncept/kotres/Exceptions.kt
+++ b/test/jp/co/qoncept/kotres/Exceptions.kt
@@ -1,4 +1,4 @@
-package jp.co.qoncept.util
+package jp.co.qoncept.kotres
 
 open class AnimalException : Exception() {}
 class DogException : AnimalException() {}

--- a/test/jp/co/qoncept/kotres/OperatorsTest.kt
+++ b/test/jp/co/qoncept/kotres/OperatorsTest.kt
@@ -1,9 +1,9 @@
-package jp.co.qoncept.util
+package jp.co.qoncept.kotres
 
 import org.testng.Assert.*
 import org.testng.annotations.Test
 
-import jp.co.qoncept.util.Result.*
+import jp.co.qoncept.kotres.Result.*
 
 class OperatorsTest {
     @Test

--- a/test/jp/co/qoncept/kotres/ResultTest.kt
+++ b/test/jp/co/qoncept/kotres/ResultTest.kt
@@ -1,9 +1,9 @@
-package jp.co.qoncept.util
+package jp.co.qoncept.kotres
 
 import org.testng.Assert.*
 import org.testng.annotations.Test
 
-import jp.co.qoncept.util.Result.*
+import jp.co.qoncept.kotres.Result.*
 
 class ResultTest {
     @Test

--- a/test/jp/co/qoncept/kotres/Sample.kt
+++ b/test/jp/co/qoncept/kotres/Sample.kt
@@ -1,9 +1,9 @@
-package jp.co.qoncept.util
+package jp.co.qoncept.kotres
 
 import org.testng.Assert.*
 import org.testng.annotations.Test
 
-import jp.co.qoncept.util.Result.*
+import jp.co.qoncept.kotres.Result.*
 
 class Sample {
     @Test


### PR DESCRIPTION
For the consistency among Qoncept's Kotlin libraries.